### PR TITLE
allow passing request_type on AddBlockedUrl

### DIFF
--- a/bing_webmaster_tools/models/content_blocking.py
+++ b/bing_webmaster_tools/models/content_blocking.py
@@ -26,8 +26,8 @@ class BlockedUrl(BingModel):
         DIRECTORY = 1
 
     class BlockedUrlRequestType(IntEnum):
-        ADD = 0
-        REMOVE = 1
+        CACHE_ONLY = 0
+        FULL_REMOVAL = 1
 
 
 class PagePreview(BingModel):

--- a/bing_webmaster_tools/services/content_blocking.py
+++ b/bing_webmaster_tools/services/content_blocking.py
@@ -58,6 +58,7 @@ class ContentBlockingService:
         site_url: str,
         blocked_url: str,
         entity_type: BlockedUrl.BlockedUrlEntityType = BlockedUrl.BlockedUrlEntityType.PAGE,
+        request_type: BlockedUrl.BlockedUrlRequestType = BlockedUrl.BlockedUrlRequestType.CACHE_ONLY,
         date: Optional[datetime] = None,
     ) -> None:
         """Add a blocked URL to a site.
@@ -66,6 +67,7 @@ class ContentBlockingService:
             site_url: The URL of the site
             blocked_url: The URL to be blocked
             entity_type: The type of entity to block (Page or Directory)
+            request_type: The type of request (CacheOnly or FullRemoval)
             date: The date the URL was blocked (default: minimum datetime)
 
         Raises:
@@ -78,7 +80,7 @@ class ContentBlockingService:
         blocked_url_data = BlockedUrl(
             date=date or datetime.now(timezone.utc),
             entity_type=entity_type,
-            request_type=BlockedUrl.BlockedUrlRequestType.ADD,
+            request_type=request_type,
             url=blocked_url,
         )
 


### PR DESCRIPTION
Per the documentation

https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.iwebmasterapi.addblockedurl?view=bing-webmaster-dotnet

https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.blockedurl.requesttype?view=bing-webmaster-dotnet#microsoft-bing-webmaster-api-interfaces-blockedurl-requesttype

https://learn.microsoft.com/en-us/dotnet/api/microsoft.bing.webmaster.api.interfaces.blockedurl.blockedurlrequesttype?view=bing-webmaster-dotnet

Name | Value 
CacheOnly | 0 |  
FullRemoval | 1


